### PR TITLE
Add missing include files to fix gcc error and warnings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+cd loader/cube
+echo
+echo Building Cube DOL Loader
+echo
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make clean
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make
+
+cd ../wii
+echo
+echo Building Wii DOL Loader
+echo
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make clean
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make
+
+cd ..
+echo
+echo Building Cube Main Loader
+echo
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.cube clean
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.cube
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.cube high=1 clean
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.cube high=1
+
+echo
+echo Building Wii Main Loader
+echo
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.wii clean
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.wii
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.wii high=1 clean
+PATH=${PATH}:/opt/devkitpro/devkitPPC/bin make -f Makefile.wii high=1
+
+cd ..
+echo
+echo Building Executable
+echo
+echo dolxz
+gcc -Wall -static -O2 -s main.c -llzma -o dolxz
+echo

--- a/main.c
+++ b/main.c
@@ -8,6 +8,8 @@
 #include <malloc.h>
 #include <lzma.h>
 #include <stdbool.h>
+#include <string.h>
+#include <errno.h>
 
 #include "loader/loader_cube.h"
 #include "loader/loader_cube_high.h"


### PR DESCRIPTION
I have added missing include files to fix the following gcc error and warnings:
```
main.c: In function 'compress':
main.c:70:7: warning: implicit declaration of function 'strerror' [-Wimplicit-function-declaration]
       strerror(errno));
       ^~~~~~~~
main.c:70:16: error: 'errno' undeclared (first use in this function)
       strerror(errno));
                ^~~~~
main.c:70:16: note: each undeclared identifier is reported only once for each function it appears in
main.c: In function 'parseCmds':
main.c:127:6: warning: implicit declaration of function 'memcmp' [-Wimplicit-function-declaration]
   if(memcmp(argv[i],"-cube",6) == 0)
      ^~~~~~
main.c: In function 'main':
main.c:146:5: warning: implicit declaration of function 'strstr' [-Wimplicit-function-declaration]
  if(strstr(argv[1],".dol") == NULL)
     ^~~~~~
main.c:146:5: warning: incompatible implicit declaration of built-in function 'strstr'
main.c:146:5: note: include '<string.h>' or provide a declaration of 'strstr'
main.c:153:5: warning: incompatible implicit declaration of built-in function 'strstr'
  if(strstr(argv[2],".dol") == NULL)
     ^~~~~~
main.c:153:5: note: include '<string.h>' or provide a declaration of 'strstr'
main.c:207:2: warning: implicit declaration of function 'memcpy' [-Wimplicit-function-declaration]
  memcpy(dolBuf, loader_dol, loader_size);
  ^~~~~~
main.c:207:2: warning: incompatible implicit declaration of built-in function 'memcpy'
main.c:207:2: note: include '<string.h>' or provide a declaration of 'memcpy'
```

I have also added a simple `build.sh` file very similar to `build.bat` to do everything automatically if you are on Linux.