### PR TITLE
include missing headers

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,6 +8,8 @@
 #include <malloc.h>
 #include <lzma.h>
 #include <stdbool.h>
+#include <errno.h>
+#include <string.h>
 
 #include "loader/loader_cube.h"
 #include "loader/loader_cube_high.h"


### PR DESCRIPTION
Includes missing `<errno.h>` and `<string.h>` headers.